### PR TITLE
Fix raw URL for curl links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ TL;DR
 
 Make sure you have VirtualBox, Anaconda, and Ibis installed. Run
 
-    curl -s http://github.com/cloudera/ibis-notebooks/raw/master/setup/bootstrap.sh | bash
+    curl -s https://raw.githubusercontent.com/cloudera/ibis-notebooks/master/setup/bootstrap.sh | bash
 
 to download the ibis-notebooks repositories and the pre-built VirtualBox image
 to get you started.

--- a/setup/README.md
+++ b/setup/README.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-    curl -s http://github.com/cloudera/ibis-notebooks/raw/master/setup/bootstrap.sh | bash
+    curl -s https://raw.githubusercontent.com/cloudera/ibis-notebooks/master/setup/bootstrap.sh | bash
 
 ## Single Steps
 


### PR DESCRIPTION
This patch makes sure the right URLs are used for curl'ing the data for bootstrapping the repository.